### PR TITLE
Research: PoC analysis of 4 CRDT frameworks

### DIFF
--- a/docs/poc-collabs-testing.md
+++ b/docs/poc-collabs-testing.md
@@ -1,0 +1,250 @@
+# PoC Analysis: Collabs TestingRuntimes for mydenicek
+
+**Date:** 2025-07-15
+**Status:** Evaluation complete — **not recommended for adoption**
+
+## 1. What TestingRuntimes Provides
+
+`TestingRuntimes` lives in `@collabs/crdts` (source: `crdts/src/util/testing_runtimes.ts`, ~120 LOC). It is a thin in-memory message-queuing harness around Collabs' own `CRuntime`.
+
+### API Surface
+
+```ts
+class TestingRuntimes {
+  // Create a new CRuntime linked to all prior runtimes
+  newRuntime(options?: {
+    rng?: seedrandom.prng;           // deterministic replicaID
+    causalityGuaranteed?: boolean;    // skip causal buffering
+    skipRedundantLoads?: boolean;     // test idempotence
+  }): CRuntime;
+
+  // Deliver queued messages from sender → recipients
+  release(sender: CRuntime, ...recipients: CRuntime[]): void;
+
+  // Deliver all queued messages between all runtimes
+  releaseAll(): void;
+
+  // Observability
+  getTotalSentBytes(): number;
+  lastMessage?: Uint8Array;
+}
+```
+
+### How It Works
+
+1. Each `CRuntime` emits a `"Send"` event containing a `Uint8Array` message.
+2. `TestingRuntimes` intercepts these events and enqueues them per (sender, recipient) pair.
+3. Messages remain queued until `release()` or `releaseAll()` is called.
+4. On release, the recipient's `CRuntime.receive(message)` is called.
+
+```
+local op → CRuntime.transact() → "Send" event
+   → TestingRuntimes queue (Map<sender, Map<recipient, Uint8Array[]>>)
+   → release(sender, recipient)
+   → CRuntime.receive(message) → deserialize → apply to Collabs
+```
+
+### Capabilities
+
+- **Selective delivery:** `release(alice, bob)` delivers only Alice's messages to Bob.
+- **Deterministic replay:** Seed-based replicaID via `seedrandom`.
+- **Causal buffering:** `CRuntime` internally buffers out-of-order messages.
+- **Byte tracking:** Sent/received byte counters for benchmarking.
+- **State transfer:** `CRuntime.save()`/`load()` for snapshot-based sync.
+
+## 2. Comparison with Our fast-check Approach
+
+| Dimension | mydenicek (fast-check) | Collabs (TestingRuntimes) |
+|---|---|---|
+| **Generation** | fast-check generates random op sequences with weighted arbitraries | Tests are hand-written or use manual loops |
+| **Shrinking** | Automatic minimal counterexample on failure | No shrinking — failures show full trace |
+| **Network model** | `sync(a, b)` as an explicit operation in the generated trace | `release(sender, ...recipients)` with per-pair queues |
+| **Delivery control** | Bidirectional sync is an atomic operation in the trace | Unidirectional: release sender→recipient only |
+| **Out-of-order delivery** | Explicit shuffled-delivery test (`OutOfOrder` suite) | CRuntime's `CausalMessageBuffer` handles internally |
+| **Sync order permutation** | Exhaustive N! permutation test | Not built-in; must be coded manually |
+| **Concurrency patterns** | 3-peer + 5-peer tests with interleaved edits/syncs | Typically 2–4 runtimes with manual scripting |
+| **Properties tested** | Convergence, idempotency, commutativity, intent preservation | Convergence (via assertions after releaseAll) |
+| **Test count** | 310 property tests × 500–2000 runs each | Typically 1–20 hand-crafted scenarios per CRDT |
+| **CRDT coupling** | Works on raw `EncodedRemoteEvent` objects (JSON-serializable) | Tightly coupled to Collabs `CRuntime` binary format |
+
+### What TestingRuntimes Adds That We Don't Have
+
+**Unidirectional selective delivery.** Our `sync(a, b)` is bidirectional — both peers exchange all missing events. TestingRuntimes can deliver Alice→Bob without delivering Bob→Alice, enabling asymmetric partition tests. However, we can already achieve this with:
+
+```ts
+for (const e of alice.eventsSince(bob.frontiers)) bob.applyRemote(e);
+```
+
+**Per-message queuing.** Messages are held individually and delivered one at a time. Our `eventsSince` returns all missing events at once. But again, we can iterate them individually if needed.
+
+### What We Already Have That TestingRuntimes Lacks
+
+- **Automatic shrinking** (fast-check)
+- **Exhaustive sync-order permutation** (`assertAllSyncOrdersConverge`)
+- **Shuffled delivery** (seed-based Fisher-Yates)
+- **Weighted operation generation** tuned per document shape
+- **5-peer convergence** tests
+- **Algebraic property verification** (idempotency, commutativity)
+
+## 3. Can TestingRuntimes Be Used Standalone?
+
+**No.** TestingRuntimes is fundamentally inseparable from the Collabs runtime:
+
+1. **CRuntime is mandatory.** `newRuntime()` returns a `CRuntime`, and `release()` calls `CRuntime.receive()`. The message format is Collabs' internal protobuf-based binary encoding — not interoperable.
+
+2. **Messages are opaque Uint8Array.** CRuntime serializes messages with `MessageSerializer` (custom binary + protobuf metadata). Our `EncodedRemoteEvent` is a plain JSON-serializable object with `{id, parents, edit, clock}`. The formats are incompatible.
+
+3. **Collabs require `registerCollab()`.** CRuntime routes messages to named Collabs registered at startup. We have a single monolithic `Denicek` document — no registration step.
+
+4. **Dependency chain.** `@collabs/crdts` → `@collabs/core` → protobufjs, seedrandom. Installing brings ~2MB of dependencies for functionality we cannot use.
+
+### Could We Extract Just the Queue Logic?
+
+The queue itself is trivial (~30 LOC):
+
+```ts
+// This is the entire queue pattern from TestingRuntimes:
+const queues = new Map<Peer, Map<Peer, Event[]>>();
+
+function enqueue(sender: Peer, event: Event) {
+  for (const [recipient, queue] of queues.get(sender)!) {
+    queue.push(event);
+  }
+}
+
+function release(sender: Peer, ...recipients: Peer[]) {
+  for (const recipient of recipients) {
+    for (const event of queues.get(sender)!.get(recipient)!) {
+      recipient.applyRemote(event);
+    }
+    queues.get(sender)!.set(recipient, []);
+  }
+}
+```
+
+We gain nothing from depending on `@collabs/crdts` for this.
+
+## 4. Concrete Integration Plan: What Would It Look Like?
+
+If we wanted TestingRuntimes-style controlled delivery, here's how we'd build it **natively** for mydenicek:
+
+```ts
+import { Denicek, type EncodedRemoteEvent } from "@mydenicek/core";
+
+class TestingNetwork {
+  private queues = new Map<Denicek, Map<Denicek, EncodedRemoteEvent[]>>();
+
+  addPeer(peer: Denicek): void {
+    const peerQueue = new Map<Denicek, EncodedRemoteEvent[]>();
+    for (const [existing, existingQueue] of this.queues) {
+      peerQueue.set(existing, []);
+      existingQueue.set(peer, []);
+    }
+    this.queues.set(peer, peerQueue);
+  }
+
+  /** Queue events produced by sender for later delivery. */
+  enqueue(sender: Denicek): void {
+    const events = sender.drain();
+    for (const [, queue] of this.queues.get(sender)!) {
+      queue.push(...events);
+    }
+  }
+
+  /** Deliver queued events from sender to specific recipients. */
+  release(sender: Denicek, ...recipients: Denicek[]): void {
+    if (recipients.length === 0) {
+      recipients = [...this.queues.keys()].filter((r) => r !== sender);
+    }
+    const senderQueues = this.queues.get(sender)!;
+    for (const recipient of recipients) {
+      for (const event of senderQueues.get(recipient)!) {
+        recipient.applyRemote(event);
+      }
+      senderQueues.set(recipient, []);
+    }
+  }
+
+  /** Deliver all queued events. */
+  releaseAll(): void {
+    for (const sender of this.queues.keys()) this.release(sender);
+  }
+}
+
+// Usage in a test:
+Deno.test("asymmetric partition convergence", () => {
+  fc.assert(
+    fc.property(
+      fc.array(arbFlatListOp, { minLength: 5, maxLength: 30 }),
+      (ops) => {
+        const net = new TestingNetwork();
+        const peers = Array.from({ length: 3 }, (_, i) => {
+          const p = new Denicek(`peer${i}`, FLAT_LIST_DOC);
+          net.addPeer(p);
+          return p;
+        });
+
+        for (const op of ops) {
+          if (op.kind === "sync") {
+            // Selective unidirectional delivery
+            net.enqueue(peers[op.a]!);
+            net.release(peers[op.a]!, peers[op.b]!);
+          } else {
+            applyEditOpWithExplicitRejection(peers[op.peer]!, op.op);
+            net.enqueue(peers[op.peer]!);
+          }
+        }
+
+        // Final full sync
+        for (const p of peers) net.enqueue(p);
+        net.releaseAll();
+        // Second pass to propagate transitive events
+        for (const p of peers) net.enqueue(p);
+        net.releaseAll();
+
+        assertConvergence(peers);
+      },
+    ),
+    { numRuns: 2000 },
+  );
+});
+```
+
+**This is ~50 lines of infrastructure** and uses our existing fast-check arbitraries, shrinking, and assertion helpers.
+
+## 5. Estimated Effort
+
+| Approach | Effort | Value |
+|---|---|---|
+| Install @collabs/crdts and try to use TestingRuntimes | 0.5 day | **Zero** — incompatible message formats |
+| Build adapter layer to bridge Collabs↔mydenicek | 3–5 days | **Negative** — maintenance burden, no new testing power |
+| Build native `TestingNetwork` (as shown above) | **0.5 day** | **High** — adds unidirectional delivery control to existing tests |
+| Extend current test suite with asymmetric partitions | 1 day | **High** — catches new bug classes |
+
+## 6. Recommendation
+
+**Do not adopt Collabs TestingRuntimes.** The reasons:
+
+1. **Incompatible architecture.** Collabs' `CRuntime` uses protobuf-encoded binary messages routed to registered Collab objects. mydenicek uses JSON-serializable `EncodedRemoteEvent` objects applied to a monolithic `Denicek` document. There is no useful interop point.
+
+2. **The queue pattern is trivial.** The only valuable idea — holding messages in a queue and releasing them selectively — is 30 lines of code that we can implement natively.
+
+3. **We already have superior testing.** Our fast-check suite provides automatic shrinking, exhaustive sync-order permutation, shuffled delivery, algebraic property verification, and 310 tests across 5 document shapes. TestingRuntimes provides none of this.
+
+4. **Unnecessary dependency.** Adding `@collabs/crdts` brings protobufjs, seedrandom, and the entire Collabs CRDT framework (~2MB) for zero functional benefit.
+
+### What To Do Instead
+
+If we want to strengthen network testing (which is a reasonable goal):
+
+1. **Build a native `TestingNetwork` class** (~50 LOC, shown in §4) that adds unidirectional delivery and per-message queuing to our existing infrastructure.
+
+2. **Add new fast-check arbitraries** for network topologies:
+   - Asymmetric partitions (A→B but not B→A)
+   - Message reordering within a single sender's stream
+   - Message duplication/replay
+   - Network healing after partition
+
+3. **Keep fast-check** for generation and shrinking — this is our real testing superpower.
+
+These additions would cost ~1.5 days and provide strictly more testing power than Collabs TestingRuntimes, without any new dependencies.

--- a/docs/poc-flec-framework.md
+++ b/docs/poc-flec-framework.md
@@ -1,0 +1,352 @@
+# PoC Analysis: Flec as a Framework for mydenicek
+
+**Date:** 2025-07-17
+**Status:** Evaluation / Feasibility study
+
+## 1. Flec's API and Architecture
+
+### 1.1 Overview
+
+Flec (Framework for Loosely-coupled Eventually Consistent systems) is a TypeScript framework for building ambient-oriented collaborative applications using pure operation-based CRDTs. It accompanies the ECOOP 2023 paper *"Nested Pure Operation-Based CRDTs"* by Jim Bauwens and Elisa Gonzalez Boix.
+
+**Repository:** https://gitlab.soft.vub.ac.be/jimbauwens/flec
+**Paper:** https://drops.dagstuhl.de/entities/document/10.4230/LIPIcs.ECOOP.2023.2
+
+### 1.2 Core Architecture
+
+Flec's architecture is structured around the following layers:
+
+```
+┌─────────────────────────────────────────────┐
+│  CRDT implementations (AWSet, MVRegister…)  │  ← user-facing
+├─────────────────────────────────────────────┤
+│  PureOpCRDT<O>                              │  ← PO-Log + redundancy hooks
+├─────────────────────────────────────────────┤
+│  CRDT_RCB<O, BD>                            │  ← Causal Reliable Broadcast
+├─────────────────────────────────────────────┤
+│  VectorClock                                │  ← causal metadata
+├─────────────────────────────────────────────┤
+│  Actor model (AmbientTalk-inspired)         │  ← networking + discovery
+└─────────────────────────────────────────────┘
+```
+
+#### `CRDT_RCB<O, BD>` — Causal Reliable Broadcast layer
+
+The base class handling:
+- **Vector clocks** (`VectorClock`): Track causal ordering across replicas
+- **Causal delivery**: Buffered operations are held until their causal dependencies are met (`tryOperation` checks `hasPrecedingDependenciesFor`)
+- **Replica discovery**: Actors discover peers via tag-based export/subscribe
+- **Stability detection**: `isCausallyStable(clock)` checks if all replicas have observed a given operation. Stable messages (`RCBOp.Stable`) are sent periodically to communicate observation progress
+- **Nested CRDT routing**: Parent CRDTs route `NestedCRDTOperation` to child CRDTs via `resolveChild()`
+- **Auth hooks**: `preApplyFilter` and `authOp` for access control policies
+
+#### `PureOpCRDT<O>` — The PO-Log
+
+Extends `CRDT_RCB` with the core pure op-based CRDT mechanics:
+
+- **Operation log** (`log: POLogEntry<O>[]`): Flat array of log entries, each carrying a `VectorClock`, operation name, and arguments
+- **Redundancy relations** (Baquero's R relations):
+  - `isArrivingOperationRedundant(entry)` — R relation: is the new op redundant upon arrival? (e.g., `remove` in AW-Set is never stored)
+  - `isPrecedingOperationRedundant(e1, e2)` — R_< relation: does a new op make a preceding entry redundant?
+  - `isConcurrentOperationRedundant(e1, e2)` — R_|| relation: does a new op make a concurrent entry redundant?
+  - `isRedundantByBufferedOperation(e, entry)` — R_β relation: for buffered (not yet causally delivered) operations
+- **Garbage collection hooks**:
+  - `markStable()` marks entries whose vector clock is causally stable
+  - `compactStable()` removes stable entries and invokes `setEntryStable()` for compaction into sequential state
+  - GC is triggered after operations via `cleanup()` when log reaches `logCompactSize`
+- **Eval**: There is no explicit `eval()` function. State is derived by iterating the log (e.g., `AWSet.toSet()` filters log entries). This is a **manual per-CRDT eval** pattern
+
+#### `POLogEntry<T>` — Log entries
+
+Each entry carries:
+- `operation: keyof T` — the operation name
+- `clock: VectorClock` — causal metadata
+- `args: any[]` — operation arguments
+- `properties: Map<string, EntryPropertyValue>` — extensible metadata (e.g., auth level)
+- Dynamic `is<Op>()` methods via Proxy (e.g., `entry.isAdd()`, `entry.isClear()`)
+- Causal comparison: `precedes()`, `isConcurrent()`, `follows()`
+
+#### Actor model
+
+Flec uses an AmbientTalk-inspired actor model for networking:
+- `Actor` manages object registration, far references, and message delivery
+- `TSAT` (Thin Switchboard for AmbientTalk) manages inter-actor communication
+- Communication via MQTT or peer-to-peer channels
+- Service discovery via tag-based export/subscribe
+
+### 1.3 CRDT Definition Pattern
+
+Defining a new CRDT in Flec requires:
+
+```typescript
+// 1. Define operations as a TypeScript interface
+interface SetOperations {
+    add(element: string);
+    remove(element: string);
+    clear();
+}
+
+// 2. Extend PureOpCRDT and override redundancy hooks
+class AWSet extends PureOpCRDT<SetOperations> {
+    // R_< : preceding entries made redundant by arriving entry
+    protected isPrecedingOperationRedundant(existing, arriving) {
+        return arriving.isClear() || existing.hasSameArgAs(arriving);
+    }
+    // R : arriving op is never stored (remove/clear are "effect-only")
+    protected isArrivingOperationRedundant(arriving) {
+        return arriving.isRemove() || arriving.isClear();
+    }
+    // Manual eval: derive state from log
+    public toSet(): Set<string> {
+        return new Set(this.getLog().map(e => e.args[0]));
+    }
+    // API methods use this.perform proxy
+    public add(element) { this.perform.add(element); }
+    public remove(element) { this.perform.remove(element); }
+}
+```
+
+### 1.4 Nesting
+
+Flec's nested CRDTs (the paper's main contribution) work by:
+- `addChild(name, childCRDT)` registers a child CRDT that shares the parent's clock
+- Operations are routed via `NestedCRDTOperation` with a path of `{key, op}` pairs
+- Parent performs a local "shell" update before forwarding to the child
+- `MultiPureOpCRDT` manages multiple instances of the same CRDT type (e.g., per-key maps)
+
+### 1.5 Maturity Assessment
+
+| Aspect | Status |
+|--------|--------|
+| PO-Log core | Functional but basic (flat array, linear scan) |
+| Redundancy relations | Clean hook-based API |
+| Stability tracking | Implemented via periodic stable messages |
+| GC / compaction | Framework exists but hooks often empty |
+| Eval / reactivity | Manual per-CRDT (no reactive framework) |
+| Networking | Tightly coupled to actor model |
+| Persistence | None |
+| Documentation | Minimal (README says "gradually updated") |
+| Tests | Present but scope unclear |
+| Code quality | Research prototype; commented-out code, TODO comments |
+| PO-Log DAG implementation | **Commented out** (`polog.ts` is entirely wrapped in `/* */`) |
+
+---
+
+## 2. Can mydenicek's Selector Rewriting Be Expressed as a Flec CRDT?
+
+### 2.1 mydenicek's Architecture Recap
+
+mydenicek implements a pure op-based CRDT for collaborative structured document editing:
+
+| Baquero concept | mydenicek implementation |
+|----------------|--------------------------|
+| **prepare** | `Denicek.commit()` — reads current doc, creates `Edit` |
+| **effect** | `EventGraph.insertEvent()` — adds tagged event to DAG |
+| **eval** | `EventGraph.materialize()` — deterministic topological replay |
+| **PO-Log** | `EventGraph.events: Map<string, Event>` — a DAG of events |
+
+Key distinguishing features:
+1. **Selector-based targeting**: Edits target document paths (`person/name`, `items/*/value`) not opaque IDs
+2. **Selector rewriting (OT)**: When concurrent structural edits (rename, wrap, delete, reindex) change the document shape, later edits' selectors are transformed to follow the new structure. This is the core of mydenicek's intention preservation
+3. **Rich edit types**: 12+ edit types (RecordAdd, RecordDelete, RecordRename, ListInsert, ListRemove, ListReorder, WrapRecord, WrapList, Copy, UpdateTag, ApplyPrimitiveEdit, CompositeEdit)
+4. **Tree document model**: Records, lists, and primitives with typed navigation
+5. **Incremental materialization**: Checkpoint cache + linear extension optimization
+6. **Undo/redo**: Inverse edit computation from pre-edit document state
+
+### 2.2 What Fits
+
+**The conceptual mapping is sound.** Both frameworks implement Baquero's pure op-based CRDT model:
+- Flec's `PureOpCRDT.onOperation()` ≈ mydenicek's `EventGraph.insertEvent()`
+- Flec's redundancy hooks ≈ mydenicek's `Event.resolveAgainst()` (concurrent edit transformation)
+- Flec's `POLogEntry` ≈ mydenicek's `Event` (operation + vector clock)
+- Flec's log iteration ≈ mydenicek's `materialize()` (though mechanisms differ radically)
+
+**Flec's hook-based redundancy relations could cleanly express simple conflict policies.** For example, a "last-writer-wins on concurrent set" is expressible as:
+
+```typescript
+isPrecedingOperationRedundant(existing, arriving) { return true; }
+```
+
+### 2.3 What Doesn't Fit
+
+**Selector rewriting is fundamentally incompatible with Flec's PO-Log model:**
+
+1. **Flec's PO-Log is a flat log with pairwise redundancy checks.** mydenicek's "redundancy" is not pairwise — it requires replaying the full causal history in topological order and transforming each edit's selector through all concurrent prior structural edits. This is an ordered transformation pipeline, not a set-membership filter.
+
+2. **Flec has no concept of document state during redundancy checking.** Flec's `isPrecedingOperationRedundant(e1, e2)` takes two log entries and compares their operations/arguments. mydenicek's `Event.resolveAgainst()` requires access to the *current document state* to determine if transformed edits are applicable (`canApply(doc)`, `validate(doc)`).
+
+3. **Flec's operations are untyped bags of arguments.** mydenicek's edits are rich objects with:
+   - `transformSelector(sel)` — how this edit changes other selectors
+   - `transformLaterConcurrentEdit(concurrent)` — full OT including payload rewriting
+   - `withTarget(target)` — retargeting
+   - `computeInverse(preDoc)` — undo
+   - `mapInsertedPayload()` / `rewritePayloadForWildcard()` — deep payload transformation
+
+   Flec's `POLogEntry` has `operation: keyof T` and `args: any[]`. The entire OT algebra would need to live outside Flec's framework.
+
+4. **Flec's eval is manual and per-type.** Each CRDT type implements its own `toSet()` / `toArray()` / `read()`. mydenicek's eval is a single generic `materialize()` that replays all edits in topological order against the document tree. This replay-based eval is inseparable from the OT-based resolution.
+
+5. **No edit identity or ordering within Flec's eval.** Flec evaluates by scanning the log for surviving entries. mydenicek requires deterministic topological ordering with tie-breaking (`EventId.compareTo`), and edits must be applied sequentially because each structural edit changes the document shape for subsequent edits.
+
+### 2.4 Verdict
+
+**mydenicek's selector rewriting cannot be expressed as a Flec CRDT.** The approaches are both "pure op-based" in Baquero's sense, but they implement the framework at fundamentally different levels of abstraction:
+
+- **Flec**: Operations are opaque tokens. Conflict resolution is pairwise redundancy filtering. Eval scans surviving log entries.
+- **mydenicek**: Operations are typed transforms with OT semantics. Conflict resolution is sequential transformation through causal history. Eval is deterministic replay with document state threading.
+
+---
+
+## 3. What We Would Gain
+
+### 3.1 PO-Log Management
+
+**Partially usable.** Flec's `PureOpCRDT` manages log insertion, buffering of out-of-order operations, and the redundancy-hook pattern. However:
+
+- mydenicek's PO-Log is a **DAG** (events have explicit parents forming a causal graph), while Flec's is a **flat array** with vector clocks. The DAG structure is essential for mydenicek's checkpoint caching, `filterCausalPast()`, `eventsSince()`, and incremental materialization.
+- mydenicek's log entries carry `Edit` objects with transform methods; Flec entries carry untyped `args`.
+- mydenicek already has battle-tested log management with bounds (`maxBufferedRemoteEvents`, `maxReplayTransformations`), deduplication, and corruption detection (`ConflictingEventPayloadError`).
+
+**Net gain: negative.** Flec's PO-Log is simpler than what mydenicek needs.
+
+### 3.2 Causal Stability
+
+**Potentially useful in isolation.** Flec's stability tracking pattern is:
+1. After all replicas acknowledge an operation, `isCausallyStable(clock)` returns true
+2. Stable entries can be compacted via `setEntryStable()` hooks
+3. Stable messages are broadcast periodically
+
+mydenicek currently has `compact()` but requires explicit frontier acknowledgment from all peers. Flec's continuous stability tracking via `remoteClocks` and periodic stable messages is a more automated approach.
+
+**However:** Flec's stability is tightly coupled to its actor model and replica discovery. Extracting it would require reimplementing the protocol. mydenicek's approach (explicit frontier-based compaction) is actually more robust for its relay-server architecture.
+
+**Net gain: marginal.** The protocol idea is interesting but the implementation is inseparable from Flec's actor model.
+
+### 3.3 Reactivity
+
+**Not available.** Despite a paper titled "Improving the reactivity of pure operation-based CRDTs" (PaPoC 2021), Flec's current codebase has **no reactive framework**. The `ReactiveAWSet` simply extends `AWSet` with the same manual `toSet()` eval. The `callback` mechanism on `CRDT_RCB` is a simple notification that *something changed*, not a reactive re-evaluation of derived state.
+
+mydenicek already has a richer change notification pattern: `Denicek.commit()` invalidates `cachedDoc`, and `materialize()` rebuilds on demand with caching. The `FormulaEngine` provides reactive formula evaluation on top.
+
+**Net gain: none.**
+
+---
+
+## 4. What We Would Lose
+
+### 4.1 DAG-Based Event Graph
+
+Flec uses a flat log + vector clocks. mydenicek's `EventGraph` is a proper DAG with:
+- Explicit parent edges enabling `filterCausalPast()`, `eventsSince()`, and causal anti-entropy sync
+- Checkpoint caching keyed by frontier hashes for O(n) incremental materialization (not O(n²))
+- Topological ordering with Kahn's algorithm for deterministic replay
+- Linear extension detection for O(1) amortized local edit application
+
+**This is mydenicek's most critical optimization.** Losing it would make materialization O(n²) for n events.
+
+### 4.2 Edit Type System
+
+mydenicek's 12+ typed edits with `transformSelector()`, `transformLaterConcurrentEdit()`, `computeInverse()`, etc. have no equivalent in Flec. The entire OT algebra would need to remain custom.
+
+### 4.3 Selector Navigation
+
+mydenicek navigates selectors against a typed tree (`Node.navigate(selector)`). Flec has no document model — it stores opaque arguments.
+
+### 4.4 Undo/Redo
+
+mydenicek's inverse-edit–based undo materializes at the pre-edit frontier and computes the structural inverse. Flec has no undo support.
+
+### 4.5 Relay Mode
+
+mydenicek's `EventGraph` supports `relayMode` where a server stores/forwards events without needing edit implementations. Flec has no equivalent.
+
+### 4.6 Conflict Surfacing
+
+mydenicek's `NoOpEdit` creates visible conflict nodes in the document tree. Flec silently discards redundant operations.
+
+### 4.7 Robustness
+
+mydenicek has configurable bounds, deduplication, corruption detection, validation against causal state, and atomicity contracts on edits. Flec is a research prototype without these safeguards.
+
+---
+
+## 5. Concrete Integration Path
+
+### 5.1 Option A: Use Flec as-is (Replace EventGraph)
+
+**Not viable.** Flec's PO-Log model (flat array + pairwise redundancy) cannot express mydenicek's replay-based OT semantics. The document model, edit type system, and materialization approach are fundamentally different.
+
+### 5.2 Option B: Extract Flec's Stability Protocol
+
+**Possible but low ROI.** The stability protocol could theoretically be extracted:
+
+1. Track `remoteClocks: Map<peerId, VectorClock>` at the sync layer
+2. After each successful broadcast, update remote clocks
+3. An event is stable when `min(remoteClocks[peer][eventPeer]) >= eventSeq` for all known peers
+4. Periodic "stable" messages piggyback on sync
+
+**What it would replace:** mydenicek's explicit `compact(acknowledgedFrontiers)` could become automatic stability-based compaction.
+
+**Cost:** ~2-3 days to implement the protocol, ~1 week to integrate with the existing sync layer and test. But this is just a protocol pattern — we don't need Flec's code for it.
+
+### 5.3 Option C: Adopt Flec's Redundancy Hook Pattern for New Simple CRDTs
+
+**Possible but niche.** If mydenicek ever needs to support standalone CRDTs alongside its document model (e.g., a replicated counter, a presence set), Flec's hook pattern is a clean API:
+
+```typescript
+class PresenceSet extends PureOpCRDT<PresenceOps> {
+    protected isPrecedingOperationRedundant(existing, arriving) { ... }
+    protected isArrivingOperationRedundant(arriving) { ... }
+}
+```
+
+**Cost:** Would require extracting `PureOpCRDT` + `POLogEntry` from Flec (~500 lines), decoupling from actor model, and adapting to mydenicek's VectorClock. ~1-2 days.
+
+### 5.4 Option D: Use Flec's Nesting Pattern for Composite Documents
+
+**Not applicable.** Flec nests CRDTs by routing operations through a parent-child tree. mydenicek already has a much richer document tree with typed nodes, selector-based navigation, and cross-node reference integrity. Flec's nesting adds nothing.
+
+### 5.5 What Must Stay Custom
+
+| Component | Reason |
+|-----------|--------|
+| `EventGraph` (DAG) | Flec's flat log cannot support incremental materialization |
+| `Event.resolveAgainst()` (OT) | Selector rewriting is mydenicek's core innovation |
+| All `Edit` subclasses | Rich typed edits with transform/inverse algebra |
+| `Node` tree + `Selector` | Typed document model with navigation |
+| `materialize()` | Replay-based eval inseparable from OT |
+| Undo/redo | Inverse computation needs document state |
+| Sync protocol | Already works with relay server; Flec's actor model is unsuitable |
+
+---
+
+## 6. Estimated Effort
+
+| Integration option | Effort | Benefit |
+|-------------------|--------|---------|
+| A. Replace EventGraph with Flec | ∞ (architectural mismatch) | N/A |
+| B. Extract stability protocol | 1-2 weeks | Automatic compaction |
+| C. Adopt hook pattern for simple CRDTs | 2-3 days | Clean API for ancillary CRDTs |
+| D. Nesting pattern | N/A | No benefit |
+
+---
+
+## 7. Recommendation
+
+**Do not adopt Flec.** The architectural mismatch is too deep.
+
+### Why
+
+1. **Flec and mydenicek solve the same problem at different abstraction levels.** Flec provides a clean framework for *simple* pure op-based CRDTs (sets, registers, counters) where conflict resolution is pairwise redundancy. mydenicek's document CRDT requires *stateful sequential replay* with operational transformation — a fundamentally different eval model that Flec cannot accommodate.
+
+2. **Flec is a research prototype.** Key infrastructure is commented out (`polog.ts`), there is no persistence, no incremental eval, minimal documentation, and tight coupling to an actor model we don't use. mydenicek's `EventGraph` is more mature for production use.
+
+3. **The usable pieces are small enough to reimplement.** The stability protocol is ~100 lines of logic. The redundancy hook pattern is a design pattern, not a library dependency. Neither justifies a framework dependency on a research prototype.
+
+### What to Take Away
+
+- **Stability protocol pattern**: If we want automatic compaction, implement Flec's `isCausallyStable()` approach directly in our sync layer. Track peer acknowledgment via vector clock exchange, mark events stable when all peers have observed them, and compact automatically. This is a self-contained protocol addition (~1-2 weeks).
+
+- **Redundancy hook API**: If we ever build standalone CRDTs (presence, awareness, ephemeral state), Flec's `isPrecedingOperationRedundant` / `isArrivingOperationRedundant` / `isConcurrentOperationRedundant` is a clean hook taxonomy. Implement it ourselves when needed.
+
+- **Declarative CRDT specification**: Flec's `set_operations.ts` sketches a decorator-based declarative CRDT definition (`@ConcurrentPriority`, `@RedundantOnArrival`, `@ClearPrevious`). This is an interesting research direction for a future higher-level API if we ever want to let users define custom conflict policies declaratively. Not actionable now, but worth watching.

--- a/docs/poc-model-guided-fuzzing.md
+++ b/docs/poc-model-guided-fuzzing.md
@@ -1,0 +1,442 @@
+# PoC Analysis: Model-Guided Fuzzing for mydenicek CRDT
+
+**Date:** 2025-07-14
+**Status:** Feasibility assessment
+**Paper:** Ozkan et al., "Model-Guided Fuzzing of Distributed Systems" ([arXiv:2410.02307](https://arxiv.org/abs/2410.02307))
+
+---
+
+## 1. Ozkan's Approach: How Model-Guided Fuzzing Works
+
+### Core Idea
+
+ModelFuzz uses an **abstract TLA+ specification** as a coverage guide for fuzzing
+real implementations. Traditional coverage-guided fuzzers (like AFL) use code-level
+metrics (line/branch coverage). ModelFuzz instead tracks **which abstract states in
+the TLA+ model** have been visited during a test execution, and prioritizes
+generating new test cases that explore under-covered model states.
+
+### The Fuzzing Loop
+
+1. **Generate** an initial set of random test cases (sequences of events/schedules).
+2. **Execute** each test case against the real implementation, intercepting system
+   events (message deliveries, crashes, restarts).
+3. **Map events to TLA+ actions** via an *event mapper* — translate concrete system
+   events into the corresponding abstract TLA+ actions.
+4. **Simulate in TLC** — feed the mapped action sequence to a *controlled TLC
+   execution* (a modified TLC model checker running in server mode on port 2023)
+   that replays the abstract actions and reports the set of TLA+ states visited.
+5. **Compute coverage** — if this execution covered **new** TLA+ states not seen
+   before, keep the test case in the corpus.
+6. **Mutate** — for each test that achieved new coverage, create N mutated variants
+   (e.g., reorder messages, inject extra crashes) and add them to the queue.
+7. **Repeat** until the time budget expires.
+
+### State Abstraction
+
+Raw TLA+ states can be too fine-grained (e.g., monotonically increasing term
+numbers in Raft create infinite new states without new *behavioral* information).
+ModelFuzz applies a post-processing **state abstraction** that merges states
+differing only in irrelevant dimensions. This does not require modifying the TLA+
+spec — it is a post-processing step on TLC output.
+
+### Key Results
+
+- Found **13 previously unknown bugs** in RedisRaft, **1 new bug** in Etcd-raft.
+- 4 of these bugs were *only* detectable via model-guided fuzzing — random,
+  line-coverage-guided, trace-coverage-guided, and RL-based approaches all missed
+  them within the same time budget.
+- Achieves 1.2–2.8× more abstract state coverage than random/trace/line-guided
+  approaches.
+- Complements RL-based approaches (BonusMaxRL): comparable coverage but better bug
+  detection due to targeted exploration of corner cases.
+
+---
+
+## 2. Tool Availability and Runtime Targets
+
+### Is ModelFuzz Open Source?
+
+**Partially.** The artifact is available on Zenodo
+([doi:10.5281/zenodo.15753950](https://doi.org/10.5281/zenodo.15753950)) and
+includes:
+
+| Component | Language | Repository |
+|---|---|---|
+| Controlled TLC server | Java (modified TLC) | `tlc-controlled/` in artifact |
+| Core fuzzing algorithm | **Go** library | `modelfuzz/` in artifact |
+| Etcd-raft fuzzer | Go | `raft-fuzzing/` |
+| RedisRaft fuzzer | Go + C | `redisraft-fuzzing/` |
+| 2PC fuzzer | Go | `2PC-Fuzzing/` |
+| Microbenchmark | C# (Coyote framework) | `coyote-concurrency-testing/` |
+| TLA+ models & configs | TLA+ | `tla-benchmarks/` |
+
+Key repositories referenced in the paper:
+- `github.com/burcuku/tlc-controlled-with-benchmarks` — modified TLC with
+  controlled execution mode (HTTP endpoint for real-time simulation)
+- `github.com/egeberkaygulcan/committer-fuzzing` — 2PC/3PC fuzzing in Go
+
+### What Language/Runtime Does It Target?
+
+The **fuzzer core** is a **Go library** (`modelfuzz/`) with abstract interfaces.
+The **controlled TLC** is Java-based. The **system under test** (SUT) can be in
+any language, but the paper's implementations are all in **Go** or **C**.
+
+The architecture requires:
+1. **Instrumenting the SUT** to intercept messages/events and expose them to the
+   fuzzer loop.
+2. **An event mapper** that translates concrete events → TLA+ abstract actions.
+3. **Network communication** with the controlled TLC server (JSON over HTTP, port
+   2023).
+
+### Can It Work with Deno/TypeScript?
+
+**Not out of the box.** The existing tool targets Go/C systems with message-passing
+architectures (Raft, 2PC). Adapting it to Deno/TypeScript would require:
+
+| Aspect | Difficulty | Notes |
+|---|---|---|
+| Running the controlled TLC server | Easy | Java; no changes needed |
+| Writing an event mapper (TS → TLA+) | Medium | Map CRDT ops to TLA+ `AllEdits` actions |
+| Instrumenting the SUT | Medium | mydenicek already exposes events via `inspectEvents()` and `eventsSince()` |
+| Writing the fuzzer loop in TS | Hard | Rewrite the Go `modelfuzz/` library in TS, or use the Go library as a sidecar |
+| Integration with fast-check | Medium | Replace the Go fuzzer loop with fast-check's generation + custom scheduler |
+
+**The fundamental mismatch:** ModelFuzz's architecture assumes a long-running SUT
+process that exchanges messages (like Raft nodes), where the fuzzer controls
+message delivery order. mydenicek is a **library** tested via in-process calls —
+there are no network messages to intercept. The fuzzer would need to control the
+*sequence of edit operations and sync events*, not message delivery.
+
+---
+
+## 3. Mapping TLA+ States to fast-check Generators
+
+### What the TLA+ Spec Models
+
+The `MydenicekCRDT.tla` spec defines a small, bounded model:
+- **Peers:** `{p1, p2, p3}` (set of peer identifiers)
+- **Events per peer:** bounded by `MaxSeq`
+- **Fields:** `FieldNames` (e.g., `{"a", "b"}`)
+- **Values:** `{"v1", "v2"}`
+- **5 edit types:** `Add`, `Rename`, `PushBack`, `Delete`, `Wrap`
+- **3 actions:** `LocalEdit(peer)`, `SendSync(from, to)`, `ReceiveSync(peer)`
+- **State:** `events` (per-peer G-Set), `nextSeq`, `channels`
+
+### What the fast-check Tests Generate
+
+The property tests use `fc.oneof(...)` with weights to generate `Op[]` sequences:
+- 10 edit types (add, delete, rename, set, insert, remove, wrapRecord, wrapList,
+  updateTag, copy)
+- sync operations between peer pairs
+- 5 document shapes (flat list, flat record, nested, deep, reference)
+- 3–5 peers, 5–120 operations per test, 500–2000 runs per property
+
+### The Mapping
+
+| TLA+ State Component | fast-check Equivalent |
+|---|---|
+| `events[peer]` (G-Set) | `peer.inspectEvents()` |
+| `nextSeq[peer]` | `peer.inspectEvents().length + 1` |
+| `channels` | Not modeled (sync is synchronous in tests) |
+| `LocalEdit(peer)` with edit ∈ `AllEdits` | `{ kind: "edit", peer, op: EditOp }` |
+| `SendSync(from, to)` + `ReceiveSync` | `{ kind: "sync", a, b }` → `sync(peers[a], peers[b])` |
+| `Materialize(events[peer])` | `peer.toPlain()` |
+| `Convergence` invariant | `assertConvergence(peers)` |
+
+### Key Gap: The TLA+ Spec Is Simpler
+
+The TLA+ spec uses a **flat record** model with 5 edit types and 2 value constants.
+The implementation supports:
+- **Nested** trees (lists of records of lists)
+- **10** edit types (including `copy`, `updateTag`, `wrapList`, `set`, `insert`,
+  `remove`)
+- **Wildcard selectors** (`rows/*`, `grid/*/*`)
+- **References** (`$ref`)
+
+The TLA+ model is a sound *abstraction* of the flat-record subset, but it does not
+cover the full implementation. Model-guided fuzzing would only guide the fuzzer
+toward interesting *flat-record edit combinations*, not nested/list scenarios.
+
+---
+
+## 4. Concrete PoC Plan: Lightweight Model-Guided Generator
+
+Instead of running the full ModelFuzz infrastructure (controlled TLC + Go library),
+we can build a **lightweight approximation** directly in TypeScript/fast-check:
+
+### Approach: TLA+ State Coverage via In-Process Simulation
+
+1. **Enumerate TLA+ abstract states** offline using TLC's simulation mode.
+   Run `tlc -simulate` on `MydenicekCRDT.tla` with small bounds (MaxSeq=3, 2
+   peers, 2 fields) and collect all reachable `(edit-type-sequence,
+   concurrent-edit-pairs)` tuples. This is the **coverage target set**.
+
+2. **Build a coverage map** that tracks which abstract edit-type combinations have
+   been tested. The key dimensions are:
+   - Which **pairs of concurrent edit types** have been tested (5×5 = 25 pairs)
+   - Which **edit-type sequences** of length 2–3 per peer have been tested
+   - Which **sync interleavings** (edit-before-sync vs. edit-after-sync) have been
+     tested
+   - Whether the **rename-vs-X transformation** path was exercised (the core of the
+     OT logic)
+
+3. **Create a model-guided fast-check `Arbitrary`** that:
+   - Maintains a coverage map across runs (using fast-check's `beforeEach` hook or
+     a module-level variable)
+   - After each test run, extracts the abstract state:
+     ```typescript
+     function abstractState(peers: Denicek[]): string {
+       // Extract: set of concurrent edit-type pairs that were resolved
+       // during materialization
+       const events = peers[0].inspectEvents();
+       const editTypes = events.map(e => e.type);
+       const concurrentPairs = findConcurrentPairs(events);
+       return JSON.stringify({ editTypes: [...new Set(editTypes)].sort(),
+                               concurrentPairs });
+     }
+     ```
+   - Biases generation toward **under-covered combinations**:
+     ```typescript
+     const modelGuidedEdit = fc.frequency(
+       ...editTypeWeights.map(([type, weight]) => ({
+         weight: baseCoverage[type] < threshold ? weight * BOOST : weight,
+         arbitrary: arbForType(type),
+       }))
+     );
+     ```
+
+4. **Prioritize the 25 concurrent-edit-type pairs** from the TLA+ spec:
+   - `Rename × Add` (the core XForm path)
+   - `Rename × Rename` (chained renames)
+   - `Rename × Delete` (rename + delete conflict)
+   - `Rename × Wrap` (rename + structural change)
+   - `Wrap × Add`, `Wrap × Delete`, etc.
+   - `Delete × Add` (resurrect after delete)
+
+   These are exactly the combinations the TLA+ `XForm` function handles. Random
+   fuzzing may under-explore rare pairs (e.g., `Wrap × Rename` with specific field
+   overlap).
+
+5. **Detect new coverage** and **mutate** by varying:
+   - The sync point (before/after which edits)
+   - The number of edits before first sync (concurrency depth)
+   - Field names (to trigger/avoid field overlap in renames)
+
+### Implementation Sketch
+
+```typescript
+// coverage-guided-arbitrary.ts
+import fc from "fast-check";
+
+type ConcurrentPair = `${string}×${string}`;
+
+const EDIT_TYPES = ["Add", "Rename", "PushBack", "Delete", "Wrap"] as const;
+const ALL_PAIRS: ConcurrentPair[] = EDIT_TYPES.flatMap((a) =>
+  EDIT_TYPES.map((b) => `${a}×${b}` as ConcurrentPair)
+);
+
+const coverageMap = new Map<ConcurrentPair, number>();
+ALL_PAIRS.forEach((p) => coverageMap.set(p, 0));
+
+function boostWeight(pair: ConcurrentPair, baseWeight: number): number {
+  const covered = coverageMap.get(pair) ?? 0;
+  return covered < 5 ? baseWeight * 10 : baseWeight;
+}
+
+/** Generate an op sequence that targets a specific concurrent pair */
+function arbTargetedSequence(
+  pair: ConcurrentPair
+): fc.Arbitrary<Op[]> {
+  const [typeA, typeB] = pair.split("×");
+  return fc.tuple(arbEditOfType(typeA), arbEditOfType(typeB)).map(
+    ([editA, editB]) => [
+      { kind: "edit", peer: 0, op: editA },
+      { kind: "edit", peer: 1, op: editB },
+      { kind: "sync", a: 0, b: 1 },
+    ]
+  );
+}
+
+/** After each test run, update coverage */
+function recordCoverage(peers: Denicek[]): void {
+  const concurrentPairs = extractConcurrentEditPairs(peers);
+  for (const pair of concurrentPairs) {
+    coverageMap.set(pair, (coverageMap.get(pair) ?? 0) + 1);
+  }
+}
+```
+
+### What This Doesn't Do (vs. Full ModelFuzz)
+
+- No real-time TLC simulation — we approximate state coverage with edit-type
+  pairs instead of full TLA+ state vectors.
+- No mutation of promising test cases — we rely on fast-check's shrinking.
+- No feedback loop within a single `fc.assert` run — fast-check generates all
+  inputs up front (though we can use `fc.scheduler` for more control).
+
+### What This Does Better Than Random
+
+- **Systematically covers all 25 concurrent edit-type pairs**, including rare ones
+  like `Wrap × Rename` that random fuzzing under-explores.
+- **Targets field-overlap scenarios** where the OT transformation is exercised (e.g.,
+  `Rename("a","b")` concurrent with `Add("a","v1")` — the exact case the TLA+
+  `XForm` handles).
+- **Controls concurrency depth** — ensures some tests have 0 syncs before N edits
+  (maximum concurrency), which random generation with sync weight 3/8 may not
+  consistently produce.
+
+---
+
+## 5. What Bugs Could This Find That Random Fuzzing Can't?
+
+### Bug Classes That Model-Guided Fuzzing Targets
+
+1. **Rare concurrent edit-type combinations.** With 10 edit types and weighted
+   random generation, some pairs are statistically under-explored. For example,
+   `wrapRecord` has weight 1 and `rename` has weight 2 in `arbFlatRecordEdit` —
+   the probability of a concurrent `wrap × rename` on the *same field* across two
+   peers is approximately:
+   ```
+   P(wrap) × P(rename_same_field) ≈ (1/13) × (2/13 × 1/5) ≈ 0.24%
+   ```
+   With 2000 runs of 50 ops each, we get ~2400 opportunities, so ~6 expected hits.
+   But with 3 peers and sync interleaving, many of those won't actually be
+   concurrent. Model guidance would guarantee coverage.
+
+2. **Deep concurrency (many edits before first sync).** The fast-check generators
+   interleave syncs with weight 3/8. The probability of having 5+ consecutive edits
+   across different peers before any sync is low. The TLA+ model explores states
+   with `MaxSeq` edits per peer before any sync — these are high-concurrency
+   scenarios where OT bugs are most likely.
+
+3. **Multi-step transformation chains.** The TLA+ `Resolve` function applies
+   `XForm` iteratively through all concurrent priors. A bug might only manifest when
+   edit C is transformed through *both* concurrent priors A and B, where A's
+   transformation changes the field that B's transformation targets. Random fuzzing
+   has low probability of generating this specific 3-way pattern.
+
+4. **Rename chain conflicts.** `Rename(a→b)` concurrent with `Rename(b→c)` — the
+   TLA+ spec handles this through `XForm` which rewrites `edit.from`. A bug could
+   occur if the implementation applies these in the wrong order or fails to chain
+   the rewrites. This is a specific 2-edit concurrent pattern that the model
+   explicitly covers but random fuzzing may not consistently hit with the right
+   field values.
+
+### Realistic Assessment
+
+Our existing test suite is already quite thorough:
+- 310 tests, 2000 runs per property, up to 120 ops per sequence
+- Multiple document shapes (flat, nested, deep, reference)
+- Sync-order permutation tests
+- Dedicated structural conflict tests (rename + wrap + add)
+
+The bugs that model-guided fuzzing is most likely to find would be in **edge cases
+of the transformation logic** where specific field overlaps matter, or in
+**very-high-concurrency scenarios** (many concurrent edits before first sync) that
+random generation under-samples.
+
+---
+
+## 6. Estimated Effort
+
+### Option A: Full ModelFuzz Integration (Java TLC + Go sidecar)
+
+| Task | Effort | Notes |
+|---|---|---|
+| Set up controlled TLC server | 2 days | Docker + Java; well-documented in artifact |
+| Write event mapper (TS → TLA+ actions) | 3–5 days | Map 5 TLA+ edit types to 10 impl edit types |
+| Write fuzzer loop in Go or TS | 5–8 days | Port `modelfuzz/` Go library or write TS equivalent |
+| Integrate with Deno test harness | 3–5 days | Subprocess management, JSON protocol |
+| Testing and tuning | 3–5 days | State abstraction, mutation strategies |
+| **Total** | **16–25 days** | ~3–5 weeks |
+
+### Option B: Lightweight Model-Guided fast-check (PoC)
+
+| Task | Effort | Notes |
+|---|---|---|
+| Enumerate TLA+ concurrent-edit-pair coverage targets | 1 day | Manual analysis of `XForm` cases |
+| Build coverage-tracking `Arbitrary` | 2–3 days | Extend existing fast-check generators |
+| Add targeted concurrent-pair generation | 2–3 days | 25 pair-specific generators |
+| Add concurrency-depth control | 1 day | Vary sync placement |
+| Integrate coverage reporting | 1 day | Log under-covered pairs |
+| **Total** | **7–9 days** | ~1.5–2 weeks |
+
+### Option C: Manual Coverage-Gap Analysis (No Tooling)
+
+| Task | Effort | Notes |
+|---|---|---|
+| Enumerate all XForm cases from TLA+ spec | 0.5 day | 5×5 = 25 cases, most are identity |
+| Write targeted hand-written tests for each case | 2–3 days | ~15 meaningful tests |
+| Add high-concurrency stress tests | 1 day | 0 syncs until all edits are done |
+| **Total** | **3–4 days** | < 1 week |
+
+---
+
+## 7. Recommendation
+
+### Go with Option B (Lightweight Model-Guided fast-check), phased:
+
+**Phase 1 (3 days): Coverage-gap analysis.**
+Enumerate the 25 concurrent edit-type pairs from the TLA+ `XForm` function. Check
+which are well-covered by existing tests by instrumenting a test run. Identify
+the under-explored pairs.
+
+**Phase 2 (5 days): Model-guided generator.**
+Build a coverage-tracking fast-check `Arbitrary` that biases toward under-explored
+pairs. Add concurrency-depth control (force high-concurrency scenarios). Run with
+10,000+ iterations and compare bug-finding rate vs. baseline.
+
+**Phase 3 (optional, if Phase 2 finds bugs): Full ModelFuzz exploration.**
+If the lightweight approach reveals that there *are* unexplored state-space regions
+with bugs, invest in the full TLC integration for systematic coverage.
+
+### Why Not Full ModelFuzz?
+
+1. **Architecture mismatch.** ModelFuzz is designed for message-passing distributed
+   systems (Raft, 2PC) where the fuzzer controls network scheduling. mydenicek is
+   a library with synchronous in-process calls. The adaptation cost is high.
+
+2. **TLA+ spec is too abstract.** The spec models a flat record with 5 edit types
+   and 2 values. The implementation has nested trees, 10 edit types, wildcards, and
+   references. Full ModelFuzz would only guide flat-record testing, missing the
+   complex nested scenarios where bugs are more likely.
+
+3. **Existing test quality is high.** With 310 tests, 2000 runs, 5 document shapes,
+   and sync-order permutation testing, the marginal value of model guidance is
+   lower than in the paper's scenarios (Etcd-raft with limited existing tests).
+
+4. **The Go library is not production-ready.** The artifact is research-quality
+   code, documented primarily for artifact evaluation. Adapting it to a TS/Deno
+   ecosystem would be more rewriting than integration.
+
+### What We Gain from the Lightweight Approach
+
+- **Systematic coverage of all OT transformation cases** — the concrete contribution
+  of the TLA+ spec to testing, without the infrastructure overhead.
+- **High-concurrency scenarios** that random fuzzing under-samples.
+- **Measurable coverage metrics** — we can report "N/25 concurrent edit-type pairs
+  covered" as a concrete testing adequacy measure for the thesis.
+- **Fast iteration** — changes to the generator are immediate, no Docker/Java/Go
+  toolchain required.
+
+---
+
+## Appendix: TLA+ XForm Coverage Matrix
+
+The `XForm(prior, edit)` function in the TLA+ spec defines how a concurrent `prior`
+transforms an `edit`. The meaningful cases (where transformation is non-trivial)
+are:
+
+| Prior ↓ / Edit → | Add | Rename | PushBack | Delete | Wrap |
+|---|---|---|---|---|---|
+| **Rename** | field rewrite if `edit.field == prior.from` | `from` rewrite if `edit.from == prior.from` | field rewrite if `edit.field == prior.from` | field rewrite if `edit.field == prior.from` | field rewrite if `edit.field == prior.from` |
+| **Delete** | identity (no-op handling in `ApplyEdit`) | identity | identity | identity | identity |
+| **Wrap** | identity (flat-model approx) | identity | identity | identity | identity |
+| **Add** | identity | identity | identity | identity | identity |
+| **PushBack** | identity | identity | identity | identity | identity |
+
+The 5 non-trivial cases (Rename × *) are the primary targets for model-guided
+generation. The field-overlap condition (`edit.field == prior.from`) is what makes
+these bugs hard to trigger randomly — it requires both peers to target the same
+field, which is `1/|FieldNames|` probability per edit pair.

--- a/docs/poc-verifx-verification.md
+++ b/docs/poc-verifx-verification.md
@@ -1,0 +1,545 @@
+# PoC: VeriFx for Automated Convergence Verification of mydenicek
+
+> **Status**: Evaluation / feasibility analysis
+> **Date**: 2025-07-18
+> **References**: [VeriFx paper](https://doi.org/10.1145/3563309) ·
+> [VeriFx repo](https://github.com/verifx-prover/verifx) ·
+> TLA+ spec: `spec/MydenicekCRDT.tla`
+
+---
+
+## 1. VeriFx Overview
+
+### 1.1 Language and DSL
+
+VeriFx is a Scala-like functional OOP language with built-in verification
+support. Programs are compiled to SMT-LIB2 formulas and discharged by Z3.
+
+Key language constructs:
+
+```verifx
+// Algebraic data types via enums
+enum CtrOp { Inc() | Dec() }
+
+// Classes with default constructors (immutable, functional updates)
+class Counter(ctr: Int = 0) extends CmRDT[CtrOp, CtrOp, Counter] {
+  def increment() = new Counter(this.ctr + 1)
+  def effect(op: CtrOp) = op match {
+    case Inc() => this.increment()
+    case Dec() => this.decrement()
+  }
+}
+
+// Proof blocks — compiled to SMT and discharged automatically
+proof commutativity {
+  forall (s: T, x: Op, y: Op) {
+    s.effect(x).effect(y) == s.effect(y).effect(x)
+  }
+}
+```
+
+Built-in collections: `Set[V]`, `Map[K,V]`, `Vector[V]`, `LList[V]`,
+`Tuple[A,B]`. Generic types and higher-order functions are supported.
+
+### 1.2 Verification Approach
+
+1. VeriFx source (`.vfx`) is parsed into an AST via scala-meta.
+2. `proof` blocks are translated to SMT-LIB2 formulas (negation of the
+   universally quantified property).
+3. Z3 checks satisfiability: **UNSAT** = property proved for all inputs,
+   **SAT** = counterexample found.
+4. Default timeout: 10 s per proof; retries with random seeds for
+   non-deterministic array-theory queries.
+
+This is **unbounded verification** — Z3 reasons over *all* possible states,
+not a finite subset. If a proof succeeds, it holds universally.
+
+### 1.3 CRDT Verification in VeriFx
+
+VeriFx ships with 40+ verified CRDTs and 8 verified OT functions.
+
+**For CmRDTs** (op-based), the proof obligation is:
+
+```
+∀ s, msg1, msg2:
+  compatible(msg1, msg2) ∧ reachable(s) ⟹
+    s.effect(msg1).effect(msg2) = s.effect(msg2).effect(msg1)
+```
+
+**For OT functions**, VeriFx verifies conditions C1 (convergence) and C2
+(composition):
+
+```
+// C1 — convergence diamond
+∀ opI, opJ, st:
+  apply(apply(st, opI), transform(opJ, opI))
+  = apply(apply(st, opJ), transform(opI, opJ))
+
+// C2 — three-way composition
+∀ opI, opJ, opK, st:
+  transform(transform(opK, opI), transform(opJ, opI))
+  = transform(transform(opK, opJ), transform(opI, opJ))
+```
+
+### 1.4 Existing OT Examples
+
+VeriFx already verifies OT functions for list editing (Ellis, Ressel, Sun,
+Suleiman, Imine) operating on `LList[V]` with insert/delete at integer
+positions. These examples are directly relevant — they verify exactly the kind
+of position-shifting rules we use for `ListInsertAtEdit`/`ListRemoveAtEdit`.
+
+---
+
+## 2. Mapping mydenicek onto VeriFx
+
+### 2.1 Architectural Mismatch
+
+mydenicek is a **pure op-based CRDT** where convergence follows from:
+
+1. Replica state is a G-Set of events (trivially convergent).
+2. `materialize` is a deterministic pure function: topological sort → resolve
+   → apply.
+3. Same event set ⟹ same document (**QED**).
+
+The hard part — which VeriFx *could* help verify — is not convergence itself
+but the **correctness of the OT-style selector rewriting rules**
+(`transformSelector` / `transformLaterConcurrentEdit`). Specifically:
+
+> Do the selector rewriting rules ensure that for any two concurrent edits,
+> applying them in either order (with transformation) produces the same
+> document?
+
+This is the classic **TP1 / C1 property** applied to mydenicek's transform
+functions.
+
+### 2.2 Can `transformSelector` Be Expressed in VeriFx?
+
+**Yes, with caveats.**
+
+Selectors are slash-separated paths: arrays of segments where each segment is
+either a string (field name) or an integer (list index). The core rewriting
+rules are:
+
+| Edit             | Rule                               | Complexity |
+| ---------------- | ---------------------------------- | ---------- |
+| Rename a → b     | `a/… → b/…`                       | Low        |
+| Delete a         | `a/… → removed`                   | Low        |
+| WrapRecord(f)    | `a/… → a/f/…`                     | Low        |
+| WrapList         | `a/… → a/*/…`                     | Medium     |
+| Insert at i      | indices ≥ i shift +1               | Low        |
+| Remove at i      | index i → removed; indices > i −1  | Low        |
+| Reorder(f,t)     | f → t with range shift             | Medium     |
+
+These are all **syntactic rewrites on finite-length selector arrays**. They
+can be encoded as operations on VeriFx `Vector[SelectorSegment]` where
+`SelectorSegment` is an enum of `Field(name: Int)` and `Index(pos: Int)`.
+
+**Limitation**: VeriFx selectors would need a bounded maximum depth. This is
+acceptable — real documents rarely exceed depth 10–15, and Z3 reasons
+symbolically over the contents at each position.
+
+**Wildcard expansion** (`*`) is harder. At transform time wildcards are not
+expanded (they stay as `*` in selectors). The tricky part is
+`rewritePayloadForWildcard`, which modifies inserted nodes to match a prior
+wildcard edit. This requires encoding a simplified document structure.
+
+### 2.3 Can `eval` (materialize) Be Expressed?
+
+**Partially, but this is the wrong question.**
+
+The full `materialize` function includes topological sort, checkpoint caching,
+and O(N²) replay — none of which need verification (they are implementation
+detail). What matters is the **pairwise transform property**:
+
+> For any state `s` and concurrent edits `e1`, `e2`:
+> `apply(apply(s, e1), transform(e2, e1)) = apply(apply(s, e2), transform(e1, e2))`
+
+This is exactly VeriFx's OT C1 condition. We encode:
+- **State** = a flat record (like the TLA+ model) or a bounded tree
+- **Op** = enum of the 11 edit types
+- **transform(x, y)** = the `transformLaterConcurrentEdit` logic
+- **apply(s, op)** = the edit's `apply` function
+
+### 2.4 State Space Analysis: Can Z3 Handle 11 Edit Types with Trees?
+
+**Estimated state space for the PoC (flat record model, like TLA+)**:
+
+| Parameter      | Value          | Impact                    |
+| -------------- | -------------- | ------------------------- |
+| Edit types     | 11 (enum)      | 11 × 11 = 121 C1 cases   |
+| Selector depth | ≤ 4 segments   | `Vector[Segment]`         |
+| Field names    | symbolic (Int) | Unbounded, handled by Z3  |
+| List indices   | symbolic (Int) | Unbounded integer theory  |
+| Document       | Flat record    | `Map[Int, Value]`         |
+
+Z3 handles integer arithmetic and case analysis well. The 121 edit-pair C1
+proofs decompose into independent proof obligations — VeriFx can split them
+into separate `proof` blocks, each targeting a specific (editA, editB) pair.
+
+**Risk: tree-structured documents.** A nested tree document (records containing
+lists containing records) requires either:
+- **Flattened encoding**: tree as `Map[Selector, Value]` (a trie). Feasible
+  for bounded depth. Z3 handles `Map` well via its array theory.
+- **Recursive ADT**: VeriFx **does not support recursion**. Cannot define
+  `Node = Record(Map[String, Node]) | List(LList[Node]) | Prim(Value)`.
+
+The flattened trie encoding is the practical path. The TLA+ spec already uses
+this approach (flat record = `Map[FieldName, Value]`).
+
+**Estimated Z3 effort per proof**: For the existing VeriFx OT examples
+(insert/delete on lists), Z3 discharges each C1 sub-case in under 10 seconds.
+Our cases are structurally similar but involve more case splitting. Expect
+10–60 seconds per proof, with some complex cases (e.g., WrapRecord vs.
+ListReorder) potentially requiring manual `reachable()` constraints.
+
+---
+
+## 3. Comparison with TLA+ Model Checking
+
+| Dimension                | TLA+ (current)                         | VeriFx (proposed)                       |
+| ------------------------ | -------------------------------------- | --------------------------------------- |
+| **Verification type**    | Bounded model checking (TLC)           | Unbounded SMT proving (Z3)              |
+| **Coverage**             | 5 edit types, 2 peers, MaxSeq=3        | All 11 edit types, arbitrary states     |
+| **Completeness**         | Sound for checked bounds only          | **Complete** — if proved, holds ∀ inputs |
+| **State explosion**      | Exponential in peers × edits           | Per-proof, no state graph               |
+| **What it verifies**     | Full system (sync + materialize + SEC) | Pairwise OT correctness (C1, C2)        |
+| **Liveness**             | Yes (EventualConvergence under WF)     | No (static properties only)             |
+| **Time to run**          | Minutes–hours                          | Seconds per proof                       |
+| **Counterexamples**      | Full execution trace                   | Symbolic (state + ops)                  |
+| **Effort to extend**     | Add to AllEdits + XForm                | One transform impl per edit type        |
+
+**Key insight**: The approaches are complementary.
+
+- **TLA+** verifies the **whole system** (sync protocol, G-Set union, full
+  materialization pipeline) but only on a small finite model. It catches
+  end-to-end bugs like incorrect topological sort tie-breaking.
+- **VeriFx** can verify **pairwise transform correctness** for all possible
+  inputs. It catches bugs like "Rename + WrapRecord don't commute when the
+  rename target is inside the wrapped subtree" — cases that the bounded TLA+
+  model may never explore.
+
+**What VeriFx gives us that TLA+ doesn't**:
+1. **Unbounded proof**: No worry about "did we pick large enough bounds?"
+2. **All 11 edit types**: The TLA+ model has 5; extending to 11 causes state
+   explosion. VeriFx handles 121 pairs independently.
+3. **Symbolic selectors**: Z3 reasons about arbitrary field names and indices,
+   not just `{"f1", "f2"}`.
+4. **Fast iteration**: Changing a transform rule and re-proving takes seconds,
+   not hours.
+
+---
+
+## 4. Concrete PoC: RecordAddEdit + RecordRenameFieldEdit
+
+### 4.1 VeriFx Encoding
+
+Below is a concrete VeriFx encoding of the two simplest record edits and
+the `transformSelector` + C1 proof. This follows the OT verification pattern
+from the existing VeriFx examples.
+
+```verifx
+// --- Selector representation ---
+// Segments are integers: positive = field name ID, negative = list index
+// Selector is a bounded-length vector of segments
+class Selector(s0: Int, s1: Int, s2: Int, len: Int) {
+  def get(i: Int): Int =
+    if (i == 0) this.s0
+    else if (i == 1) this.s1
+    else this.s2
+
+  def withSeg(i: Int, v: Int): Selector =
+    if (i == 0) new Selector(v, this.s1, this.s2, this.len)
+    else if (i == 1) new Selector(this.s0, v, this.s2, this.len)
+    else new Selector(this.s0, this.s1, v, this.len)
+}
+
+// --- Edit types ---
+enum RecordEdit {
+  Add(target: Selector, value: Int) |
+  Delete(target: Selector) |
+  Rename(target: Selector, toField: Int) |
+  NoOp()
+}
+
+// --- Flat-record document: Map from field-name ID to value ---
+class FlatDoc(fields: Map[Int, Int]) {
+  def get(f: Int): Int = this.fields.getOrElse(f, 0)
+  def set(f: Int, v: Int): FlatDoc =
+    new FlatDoc(this.fields.add(f, v))
+  def remove(f: Int): FlatDoc =
+    new FlatDoc(this.fields.remove(f))
+  def rename(from: Int, to: Int): FlatDoc = {
+    val v = this.fields.getOrElse(from, 0)
+    new FlatDoc(this.fields.remove(from).add(to, v))
+  }
+}
+
+// --- transformSelector for Rename ---
+// If the selector's first segment matches the rename source,
+// rewrite it to the rename target.
+def transformSelectorRename(sel: Selector, renFrom: Int, renTo: Int): Selector = {
+  if (sel.len > 0 && sel.get(0) == renFrom)
+    sel.withSeg(0, renTo)
+  else
+    sel
+}
+
+// --- Transform: rewrite a later concurrent edit through a prior ---
+def transform(prior: RecordEdit, later: RecordEdit): RecordEdit = {
+  prior match {
+    case Rename(target, toField) => {
+      val renFrom = target.get(target.len - 1)
+      later match {
+        case Add(t, v) =>
+          new Add(transformSelectorRename(t, renFrom, toField), v)
+        case Delete(t) =>
+          if (t.len > 0 && t.get(0) == renFrom)
+            new Delete(transformSelectorRename(t, renFrom, toField))
+          else
+            later
+        case Rename(t, to2) =>
+          if (t.len > 0 && t.get(0) == renFrom)
+            new Rename(transformSelectorRename(t, renFrom, toField), to2)
+          else
+            later
+        case NoOp() => later
+      }
+    }
+    case Delete(target) => {
+      val delField = target.get(target.len - 1)
+      later match {
+        case Add(t, v) =>
+          // Add to deleted field: still apply (add overwrites)
+          later
+        case Delete(t) =>
+          if (t.len > 0 && t.get(0) == delField) new NoOp()
+          else later
+        case Rename(t, to2) =>
+          if (t.len > 0 && t.get(0) == delField) new NoOp()
+          else later
+        case NoOp() => later
+      }
+    }
+    case _ => later  // Add and NoOp don't transform selectors
+  }
+}
+
+// --- Apply edit to document ---
+def applyEdit(doc: FlatDoc, edit: RecordEdit): FlatDoc = {
+  edit match {
+    case Add(t, v) => doc.set(t.get(0), v)
+    case Delete(t) => doc.remove(t.get(0))
+    case Rename(t, to) => doc.rename(t.get(0), to)
+    case NoOp() => doc
+  }
+}
+
+// --- C1 proof: convergence diamond ---
+object RecordOT {
+  proof C1_AddAdd {
+    forall (doc: FlatDoc, e1: RecordEdit, e2: RecordEdit) {
+      (e1.isInstanceOf[Add] && e2.isInstanceOf[Add]) =>:
+        (applyEdit(applyEdit(doc, e1), transform(e1, e2))
+         == applyEdit(applyEdit(doc, e2), transform(e2, e1)))
+    }
+  }
+
+  proof C1_AddRename {
+    forall (doc: FlatDoc, e1: RecordEdit, e2: RecordEdit) {
+      (e1.isInstanceOf[Add] && e2.isInstanceOf[Rename]) =>:
+        (applyEdit(applyEdit(doc, e1), transform(e1, e2))
+         == applyEdit(applyEdit(doc, e2), transform(e2, e1)))
+    }
+  }
+
+  proof C1_RenameRename {
+    forall (doc: FlatDoc, e1: RecordEdit, e2: RecordEdit) {
+      (e1.isInstanceOf[Rename] && e2.isInstanceOf[Rename]) =>:
+        (applyEdit(applyEdit(doc, e1), transform(e1, e2))
+         == applyEdit(applyEdit(doc, e2), transform(e2, e1)))
+    }
+  }
+
+  // ... one proof per (editType1, editType2) pair
+}
+```
+
+### 4.2 What This PoC Tests
+
+This encoding verifies, **for all possible field names, values, and document
+states**, that:
+
+- Concurrent Add + Add converge
+- Concurrent Add + Rename converge (the rename rewrites the add's field)
+- Concurrent Rename + Rename converge (chained rewriting)
+- Concurrent Delete + Add converge
+- Concurrent Delete + Rename converge (rename becomes no-op)
+- Concurrent Delete + Delete converge
+
+This is a strict superset of what the TLA+ model checks for these edit types,
+because TLA+ only checks `{f1, f2} × {v1, v2}` while VeriFx proves it for
+all integers.
+
+### 4.3 Expected Outcome
+
+Based on the existing VeriFx OT examples (which verify similar list-OT
+functions in <10 s each), we expect:
+
+- **3 × 3 = 9 proof obligations** for {Add, Delete, Rename} × {Add, Delete, Rename}
+- Each proof: **5–30 seconds** on a modern machine
+- Total PoC: **~5 minutes** Z3 time
+
+If any proof fails, Z3 returns a **concrete counterexample**: specific field
+names, values, and document state that violate C1 — directly actionable for
+debugging.
+
+---
+
+## 5. Feasibility of Full 11-Edit-Type Verification
+
+### 5.1 Edit-Pair Matrix
+
+With 11 edit types, C1 requires **11 × 11 = 121** proof obligations (or 66
+unique pairs if we exploit symmetry). Grouped by complexity:
+
+| Category                      | Pairs | Difficulty | Notes                                    |
+| ----------------------------- | ----- | ---------- | ---------------------------------------- |
+| Record × Record               | 9     | Low        | Flat field rewrites (PoC above)          |
+| Record × List                 | 9     | Medium     | Cross-type: rename doesn't affect index  |
+| List × List                   | 9     | Medium     | Index shifting (like existing VeriFx OT) |
+| Record × Tree (Wrap/Unwrap)   | 12    | Medium     | Selector insertion/removal               |
+| List × Tree                   | 12    | High       | Index shift + path insertion             |
+| Tree × Tree                   | 16    | High       | Nested path transformations              |
+| Anything × Copy               | 20    | Very High  | Two selectors, mirroring                 |
+| Anything × ApplyPrimitive     | 10    | Low        | Non-structural, identity transform       |
+
+### 5.2 Encoding Challenges
+
+**Selector depth.** The real system has unbounded selectors. In VeriFx we must
+fix a maximum depth (e.g., 4–6 segments). This is not a fundamental limitation
+— if the transform is correct for depth-k selectors, it is correct for
+depth-(k+1) by structural induction on the suffix (which is not touched by the
+transform). We can state this inductive argument informally and verify the
+base cases mechanically.
+
+**WrapRecord/WrapList path insertion.** These edits insert a new segment into
+the middle of a selector:
+
+```
+WrapRecord("items/0", field="inner"):
+  sel "items/0/name" → "items/0/inner/name"
+```
+
+This requires shifting all segments after the match point. Encodable with
+bounded-depth `Vector`, but requires careful index arithmetic.
+
+**CopyEdit mirroring.** CopyEdit has two selectors and creates mirror edits
+(CompositeEdit). This is the most complex case — it requires encoding the
+mirror-creation logic and verifying that the composite edit commutes. May
+require decomposing into sub-lemmas.
+
+**Wildcard expansion.** Wildcards are not expanded at transform time — they
+stay as `*`. The `rewritePayloadForWildcard` hook modifies inserted payloads.
+Encoding this requires a simplified document model where we can "apply" an
+edit to a subtree. Feasible but adds encoding complexity.
+
+**Negative/strict indices.** Negative indices are resolved using a stored
+`listLength`. Strict indices skip shifting. These are straightforward integer
+conditions, well within Z3's capabilities.
+
+### 5.3 What VeriFx Cannot Verify
+
+1. **Full-system convergence**: VeriFx verifies pairwise OT correctness, not
+   the end-to-end system (sync, topological sort, checkpoint cache). Keep TLA+
+   for system-level properties.
+
+2. **N-way commutativity**: C1 proves pairwise commutativity. For N > 2
+   concurrent edits, you need C2 (three-way composition) or an inductive
+   argument. VeriFx can verify C2 but the formula is larger (3 ops × state).
+   However, mydenicek doesn't need classical C2 because the replay order is
+   fixed — the edits are not applied in arbitrary peer-local orders but in a
+   deterministic global order. What we actually need is that `resolveAgainst`
+   (sequential transformation through all concurrent priors) is
+   order-independent when the priors are reordered. This is a custom property
+   we would need to formulate.
+
+3. **Recursive tree traversal**: `canApply` and `apply` navigate the document
+   tree recursively. VeriFx cannot encode this. We verify the *transform*
+   (selector rewriting) correctness, and trust `apply` via testing.
+
+4. **Intention preservation**: "Did the user get what they meant?" is a design
+   choice, not a formal property. VeriFx can verify convergence (everyone sees
+   the same thing) but not intent.
+
+### 5.4 Effort Estimate
+
+| Phase                                        | Effort     | Output                                  |
+| -------------------------------------------- | ---------- | --------------------------------------- |
+| VeriFx environment setup (Scala + Z3)        | 1–2 days   | Running VeriFx with existing examples   |
+| PoC: 3 record edits (§4)                     | 2–3 days   | 9 C1 proofs, validated                  |
+| Extend to list edits (Insert, Remove, Reorder) | 3–5 days | +27 pairs (leveraging VeriFx list OT)   |
+| Add tree edits (Wrap, Unwrap, UpdateTag)     | 5–7 days   | +48 pairs, bounded-depth selectors      |
+| CopyEdit + mirroring                         | 3–5 days   | +20 pairs, CompositeEdit encoding       |
+| ApplyPrimitiveEdit (trivial)                 | 0.5 days   | +10 pairs (identity transform)          |
+| C2 / sequential-resolve proof                | 3–5 days   | Optional: 3-way composition             |
+| Documentation + integration                  | 2–3 days   | Proof artifacts, CI integration         |
+| **Total**                                    | **~4–6 weeks** | **121 C1 proofs + optional C2**     |
+
+---
+
+## 6. Recommendation
+
+### Use VeriFx for pairwise OT verification; keep TLA+ for system-level checking.
+
+**Rationale**:
+
+1. **VeriFx is a strong fit for verifying `transformSelector` rules.** These
+   are exactly the kind of syntactic rewriting functions VeriFx was built to
+   verify — see the existing OT examples (Ellis, Ressel, etc.) which verify
+   analogous list-position transformations.
+
+2. **Unbounded proofs close the gap left by TLA+.** The TLA+ model covers 5 of
+   11 edit types with small bounds. VeriFx can cover all 121 edit pairs with
+   symbolic (unbounded) field names and indices.
+
+3. **The encoding is tractable.** The core transform rules are syntactic
+   rewrites on bounded-depth selectors — well within Z3's capabilities.
+   Existing VeriFx OT examples discharge similar proofs in seconds.
+
+4. **CopyEdit is the main risk.** Its two-selector + mirroring design is
+   significantly more complex than anything in VeriFx's existing examples.
+   Budget extra time and consider simplifying the encoding (e.g., verify the
+   mirror-creation logic separately from the selector rewriting).
+
+5. **Keep TLA+ running.** VeriFx verifies OT correctness (pairwise), not
+   end-to-end system convergence. TLA+ catches bugs in the sync protocol,
+   topological sort, and materialization pipeline. The two tools are
+   complementary.
+
+### Suggested roadmap
+
+1. **Week 1**: Set up VeriFx, reproduce existing OT examples, implement the
+   3-edit PoC from §4. If any C1 proof fails, investigate whether it's an
+   encoding error or a real transform bug.
+
+2. **Week 2–3**: Extend to all 11 edit types with flat-record document model.
+   Start with non-structural edits (trivial), then record edits, then list
+   edits, then tree edits.
+
+3. **Week 4–5**: Tackle CopyEdit mirroring and wildcard-payload rewriting.
+   These are the hardest cases and may require manual lemma decomposition.
+
+4. **Week 6**: Optional C2 / sequential-resolve property. Write up proof
+   artifacts. Integrate proof-checking into CI (VeriFx proofs run in seconds
+   and can be a build step).
+
+### What success looks like
+
+- **121 C1 proof obligations discharged**, covering all edit-type pairs
+- **Symbolic counterexamples** for any bugs found during encoding
+- **Confidence statement**: "The selector rewriting rules of mydenicek are
+  verified correct (convergent) for all possible selector paths of depth ≤ k,
+  all field names, all list indices, and all document states, via automated
+  SMT proving."
+- This is a **strictly stronger guarantee** than the current TLA+ bounded
+  model, complementing it rather than replacing it.


### PR DESCRIPTION
## Summary

Detailed feasibility analysis of integrating 4 research frameworks with mydenicek:

| Framework | Paper | Verdict | Action |
|---|---|---|---|
| **Collabs TestingRuntimes** | Weidner OOPSLA'23 | Not usable standalone | Build native TestingNetwork |
| **Flec** | Bauwens ECOOP'23 | Architectural mismatch | Reimplement stability patterns |
| **VeriFx** | Bauwens OOPSLA'22 | **Strong fit** for OT verification | Encode edit pairs for SMT proofs |
| **Model-guided fuzzing** | Ozkan OOPSLA'25 | Tool not TS-compatible | Build coverage-guided fast-check |

## Key finding
VeriFx is the most promising integration — it can mechanically verify the 121 edit-type pairs (11×11) that our selector rewriting must handle correctly. The other frameworks are either too tightly coupled to their own runtimes (Collabs, Flec) or target different language ecosystems (ModelFuzz).

## Practical next steps
1. **VeriFx PoC** (4-6 weeks): Encode Add+Delete+Rename in VeriFx, verify C1 property
2. **Coverage-guided fuzzer** (1.5-2 weeks): fast-check generator biased toward under-explored edit-type pairs from TLA+ model
3. **Native TestingNetwork** (~1 day): Deterministic message delivery for integration tests

Closes #16 #17 #18 #19